### PR TITLE
avfs: fix compatibility with go 1.23

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: [1.22.x]
+        go: [1.22.x, 1.23.x]
         os: [ubuntu-latest, windows-latest]
 
     runs-on: ${{ matrix.os }}

--- a/test/test_file.go
+++ b/test/test_file.go
@@ -656,9 +656,10 @@ func (ts *Suite) TestFileSeek(t *testing.T, testDir string) {
 
 	pos := int64(0)
 	lenData := int64(len(data))
+	lenDataInt := int(lenData)
 
 	t.Run("TestFileSeek", func(t *testing.T) {
-		for i := range len(data) {
+		for i := range lenDataInt {
 			pos, err = f.Seek(int64(i), io.SeekStart)
 			RequireNoError(t, err, "Seek %s", path)
 
@@ -667,7 +668,7 @@ func (ts *Suite) TestFileSeek(t *testing.T, testDir string) {
 			}
 		}
 
-		for i := range len(data) {
+		for i := range lenDataInt {
 			pos, err = f.Seek(-int64(i), io.SeekEnd)
 			RequireNoError(t, err, "Seek %s", path)
 

--- a/vfs.go
+++ b/vfs.go
@@ -628,9 +628,6 @@ func VolumeName[T VFSBase](vfs T, path string) string {
 	return FromSlash(vfs, path[:VolumeNameLen(vfs, path)])
 }
 
-//go:linkname volumeNameLen path/filepath.volumeNameLen
-func volumeNameLen(path string) int
-
 // WalkDir walks the file tree rooted at root, calling fn for each file or
 // directory in the tree, including root.
 //

--- a/vfs_volumenamelen.go
+++ b/vfs_volumenamelen.go
@@ -1,0 +1,8 @@
+//go:build go1.23
+
+package avfs
+
+import _ "unsafe" // for go:linkname only.
+
+//go:linkname volumeNameLen internal/filepathlite.volumeNameLen
+func volumeNameLen(path string) int

--- a/vfs_volumenamelen_old.go
+++ b/vfs_volumenamelen_old.go
@@ -1,0 +1,8 @@
+//go:build !go1.23
+
+package avfs
+
+import _ "unsafe" // for go:linkname only.
+
+//go:linkname volumeNameLen path/filepath.volumeNameLen
+func volumeNameLen(path string) int


### PR DESCRIPTION
In go 1.23, filepath.volumeNameLen has moved to internal/filepathlite.volumeNameLen.

Drive-by: fix golangci-lint errors.